### PR TITLE
feat: port pixel size override from upstream

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Place this folder inside `ComfyUI/custom_nodes/` and restart ComfyUI.
 - `image` – ComfyUI `IMAGE` tensor (batch supported; returns a list).
 - `k_colors` (int) – Palette size (default 16).
 - `k_seed` (int) – RNG seed for palette init (default 42).
+- `pixel_size` (float) – Override the auto-detected input pixel size; `0.0` keeps auto-detection. Values must be between `1` and half the smallest image dimension.
 - `output_scale` (int) – Optional integer upscaling after snapping (nearest-neighbor, default 1, max 16).
 
 Advanced parameters mirror the original Rust defaults and can be tweaked:

--- a/pixel_snapper_node.py
+++ b/pixel_snapper_node.py
@@ -20,6 +20,7 @@ import torch
 @dataclass
 class Config:
     k_colors: int = 16
+    pixel_size_override: float = 0.0
     k_seed: int = 42
     max_kmeans_iterations: int = 15
     peak_threshold_multiplier: float = 0.2
@@ -251,6 +252,9 @@ def resolve_step_sizes(
     height: int,
     config: Config,
 ) -> Tuple[float, float]:
+    if config.pixel_size_override != 0.0:
+        return config.pixel_size_override, config.pixel_size_override
+
     if step_x_opt is not None and step_y_opt is not None:
         sx, sy = step_x_opt, step_y_opt
         ratio = sx / sy if sx > sy else sy / sx
@@ -530,6 +534,14 @@ def process_image_array(img: np.ndarray, config: Config) -> np.ndarray:
         raise PixelSnapperError("Input image contains NaN or Inf values.")
 
     validate_image_dimensions(w, h)
+    if config.pixel_size_override != 0.0:
+        max_pixel_size = min(w, h) / 2.0
+        px = config.pixel_size_override
+        if not math.isfinite(px) or px < 1.0 or px > max_pixel_size:
+            raise PixelSnapperError(
+                f"pixel_size_override {px:.1f} is out of valid range "
+                f"[1, {int(max_pixel_size)}]"
+            )
 
     quantized = quantize_image(img, config)
     profile_x, profile_y = compute_profiles(quantized)
@@ -586,6 +598,16 @@ class PixelSnapperNode:
                 ),
             },
             "optional": {
+                "pixel_size": (
+                    "FLOAT",
+                    {
+                        "default": 0.0,
+                        "min": 0.0,
+                        "max": 10000.0,
+                        "step": 0.1,
+                        "tooltip": "Override detected pixel size in input pixels; 0 keeps auto-detection",
+                    },
+                ),
                 "output_scale": (
                     "INT",
                     {
@@ -694,6 +716,7 @@ class PixelSnapperNode:
         image: torch.Tensor,
         k_colors: int,
         k_seed: int,
+        pixel_size: float = 0.0,
         output_scale: int = 1,
         max_kmeans_iterations: int = 15,
         peak_threshold_multiplier: float = 0.2,
@@ -707,6 +730,7 @@ class PixelSnapperNode:
     ):
         config = Config(
             k_colors=k_colors,
+            pixel_size_override=pixel_size,
             k_seed=k_seed,
             max_kmeans_iterations=max_kmeans_iterations,
             peak_threshold_multiplier=peak_threshold_multiplier,

--- a/pixel_snapper_node.py
+++ b/pixel_snapper_node.py
@@ -598,16 +598,6 @@ class PixelSnapperNode:
                 ),
             },
             "optional": {
-                "pixel_size": (
-                    "FLOAT",
-                    {
-                        "default": 0.0,
-                        "min": 0.0,
-                        "max": 10000.0,
-                        "step": 0.1,
-                        "tooltip": "Override detected pixel size in input pixels; 0 keeps auto-detection",
-                    },
-                ),
                 "output_scale": (
                     "INT",
                     {
@@ -703,6 +693,16 @@ class PixelSnapperNode:
                         "tooltip": "Max allowed X/Y step ratio before snapping to a uniform grid",
                     },
                 ),
+                "pixel_size": (
+                    "FLOAT",
+                    {
+                        "default": 0.0,
+                        "min": 0.0,
+                        "max": 10000.0,
+                        "step": 0.1,
+                        "tooltip": "Override detected pixel size in input pixels; 0 keeps auto-detection",
+                    },
+                ),
             },
         }
 
@@ -716,7 +716,6 @@ class PixelSnapperNode:
         image: torch.Tensor,
         k_colors: int,
         k_seed: int,
-        pixel_size: float = 0.0,
         output_scale: int = 1,
         max_kmeans_iterations: int = 15,
         peak_threshold_multiplier: float = 0.2,
@@ -727,6 +726,7 @@ class PixelSnapperNode:
         min_cuts_per_axis: int = 4,
         fallback_target_segments: int = 64,
         max_step_ratio: float = 1.8,
+        pixel_size: float = 0.0,
     ):
         config = Config(
             k_colors=k_colors,

--- a/pixel_snapper_node.py
+++ b/pixel_snapper_node.py
@@ -540,7 +540,7 @@ def process_image_array(img: np.ndarray, config: Config) -> np.ndarray:
         if not math.isfinite(px) or px < 1.0 or px > max_pixel_size:
             raise PixelSnapperError(
                 f"pixel_size_override {px:.1f} is out of valid range "
-                f"[1, {int(max_pixel_size)}]"
+                f"[1, {max_pixel_size:.1f}]"
             )
 
     quantized = quantize_image(img, config)


### PR DESCRIPTION
Ports the upstream pixel-size override feature added in PR 8 of Hugo-Dz/spritefusion-pixel-snapper.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional pixel size override parameter to the Pixel Snapper Node, allowing manual specification of grid step sizes instead of auto-detection.

* **Documentation**
  * Updated Node input documentation with pixel size parameter details and valid value constraints.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/x0x0b/ComfyUI-spritefusion-pixel-snapper/pull/8?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->